### PR TITLE
Add Azure pipeline build file

### DIFF
--- a/Content/azure-pipeline.yml
+++ b/Content/azure-pipeline.yml
@@ -1,0 +1,25 @@
+trigger:
+  - master
+  
+pool:
+  vmImage: "vs2017-win2016"
+
+variables:
+  buildConfiguration: "Release"
+
+steps:
+  - script: dotnet build --configuration $(buildConfiguration)
+    displayName: "Building"
+  - script: dotnet publish --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)
+    displayName: "Packaging"
+  - task: ArchiveFiles@2
+    displayName: "Archiving"
+    inputs:
+      rootFolderOrFile: "$(Build.ArtifactStagingDirectory)"
+      includeRootFolder: false
+      archiveFile: "$(Build.ArtifactStagingDirectory)/package/build-$(Build.BuildId).zip"
+      archiveType: "zip"
+  - task: PublishBuildArtifacts@1
+    displayName: "Publishing"
+    inputs:
+      pathtoPublish: "$(Build.ArtifactStagingDirectory)/package"


### PR DESCRIPTION
The build file acts as a useful starting point for configuring automated builds within Azure dev ops. The automated build will compile, package, archive & publish a project.

Testing this may be a challenge without actually creating a new build within Azure dev ops, so a sanity check may be all you can do. 

Would be good to get your opinion on the filename, "azure-pipelines.yml" could potentially be generic, e.g. "build.yml". Not sure if Azure dev ops is looking for that filename specifically when automatically detecting a build pipeline, but you can definitely define which `.yml` file in the source code to use when creating a manual build pipeline.