### PR TITLE
Add documentation for adding themes

### DIFF
--- a/Content/Moov2.OrchardCore.SiteBoilerplate.sln
+++ b/Content/Moov2.OrchardCore.SiteBoilerplate.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 15.0.28307.168
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moov2.OrchardCore.SiteBoilerplate", "src\Moov2.OrchardCore.SiteBoilerplate\Moov2.OrchardCore.SiteBoilerplate.csproj", "{4EAEB124-E0A2-495A-914B-9529008E6AAA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Themes", "Themes", "{A2CEBE77-E664-4836-939B-1DF8EAC03997}"
+	ProjectSection(SolutionItems) = preProject
+		src\Themes\README.md = src\Themes\README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Content/src/Themes/README.md
+++ b/Content/src/Themes/README.md
@@ -1,0 +1,11 @@
+# Themes
+
+Add themes that are specific to this project in this directory. Generic themes that could likely be reused on other projects should have their own Git repository and made available on NuGet (e.g. https://github.com/moov2/Moov2.OrchardCore.EventsTheme).
+
+## Creating new Theme
+
+If you're creating a new theme why not use the [theme boilerplate project](https://github.com/moov2/Moov2.OrchardCore.ThemeBoilerplate) to do all the set up and allow you to focus on theming.
+
+### Installing Theme
+
+Once the theme has been added to the "Themes" directory, open the solution in Visual Studio, right click the "Themes" directory in Solution Explorer and add an existing project. Add the theme as a dependency in the `Moov2.OrchardCore.SiteBoilerplate` project, which will make the theme available within Orchard Core CMS.


### PR DESCRIPTION
Adding directory in the `src` folder that can contain any bespoke themes for the project. Within this directory is documentation for explaining a few things:

- Whether the theme should be included in the project or via NuGet
- How to quickly create a new theme using our theme template
- How to make the theme available in the Orchard Core CMS