### PR TITLE
Fix exception when running within Azure web app

### DIFF
--- a/Content/src/Moov2.OrchardCore.SiteBoilerplate/Moov2.OrchardCore.SiteBoilerplate.csproj
+++ b/Content/src/Moov2.OrchardCore.SiteBoilerplate/Moov2.OrchardCore.SiteBoilerplate.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TieredCompilation>true</TieredCompilation>
+    <MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When running an Orchard Core instance within an Azure environment, when
a custom theme is enabled an exception prevents the front end from being
accessible. Below is a snipprt of the logged exception.

```
System.InvalidOperationException: Cannot find compilation library location for package 'Microsoft.NETCore.App'
```

To fix this issue (discussed here - https://github.com/OrchardCMS/OrchardCore/issues/1156)
a couple of properties need to be added to the csproj for the main site
project.

Fixes #3.