### PR TITLE
Add is-cache to .gitignore

### DIFF
--- a/Content/.gitignore
+++ b/Content/.gitignore
@@ -234,6 +234,9 @@ orleans.codegen.cs
 # ASP.NET Core default setup: bower directory is configured as wwwroot/lib/ and bower restore is true
 **/wwwroot/lib/
 
+# Orchard image cache
+**/wwwroot/is-cache/
+
 # RIA/Silverlight projects
 Generated_Code/
 


### PR DESCRIPTION
Add the `/wwwroot/is-cache` image cache directory which is created by Orchard to the Content's `.gitignore` file.

Fixes #8 